### PR TITLE
Mantener visible la lista de túneles SSH

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,14 +21,8 @@
       {% endif %}
     {% endwith %}
 
-    <!-- Apartado Status desplegable -->
-    <div class="mb-3">
-        <button class="btn btn-info" type="button" data-bs-toggle="collapse" data-bs-target="#statusPanel" aria-expanded="false" aria-controls="statusPanel">
-            Mostrar Estado
-        </button>
-    </div>
-
-    <div class="collapse" id="statusPanel">
+    <!-- Apartado Status -->
+    <div id="statusPanel">
         <div class="card card-body">
             <h4>Estado de Túneles Abiertos</h4>
             {% if processes %}


### PR DESCRIPTION
## Summary
- elimina el botón "Mostrar Estado" y deja visible la sección de túneles

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68876c1d2598832396ce0394a3f9dc6a