### PR TITLE
Implement auto refresh to update tunnel status

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -169,5 +169,12 @@ function askSSHPassword(scriptPath) {
   }
 }
 </script>
+<!-- Recarga periódica para comprobar el estado de los túneles -->
+<script>
+  // Recarga la página cada 60 segundos para actualizar el panel de estado
+  setInterval(function() {
+    window.location.reload();
+  }, 60000);
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh index page every minute so closed tunnels don't appear running

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688771b6024083239ebc3a2b704bc435